### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/scantree/_path.py
+++ b/src/scantree/_path.py
@@ -25,7 +25,7 @@ class RecursionPath(object):
     root = attr.ib()
     relative = attr.ib()
     real = attr.ib()
-    _dir_entry = attr.ib(cmp=False)
+    _dir_entry = attr.ib(eq=False, order=False)
 
     @classmethod
     def from_root(cls, directory):
@@ -123,7 +123,7 @@ RecursionPath.__getstate__ = RecursionPath._getstate
 RecursionPath.__setstate__ = RecursionPath._setstate
 
 
-@attr.s(slots=True, cmp=False)
+@attr.s(slots=True, eq=False, order=False)
 class DirEntryReplacement(object):
     """Pure python implementation of the `DirEntry` interface (found in the external
     `scandir` module in Python < 3.5 or builtin `posix` module in Python >= 3.5)


### PR DESCRIPTION
Using one of my dependencies is in turn depending on `scantree`, causing the following warning to be logged:
```
~/.pyenv/versions/3.8.3/envs/<redacted>/lib/python3.8/site-packages/scantree/_path.py:126
  ~/.pyenv/versions/3.8.3/envs/<redacted>/lib/python3.8/site-packages/scantree/_path.py:126: DeprecationWarning: The usage of `cmp` is deprecated and will be removed on or after 2021-06-01.  Please use `eq` and `order` instead.
    @attr.s(slots=True, cmp=False)
```
This PR fixes this.

Not 100% this will work on Python 2 (I wasn't able to run the test suite on Py2 even on an unchanged `master`) but since it's EOL anyway I figured it might not be a problem...