### PR TITLE
Use tox-gh-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
+        python -m pip install tox tox-gh-actions
     - name: Cache tox environments
       id: cache-tox
       uses: actions/cache@v1

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,10 @@ deps =
 commands =
     pytest --cov=scantree --cov-report=xml --cov-report=term-missing --cov-config=.coveragerc tests/
 
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312


### PR DESCRIPTION
With tox-gh-actions, tox filter only the environments with the current python version, making CI faster (not relevant for a small project) and CI logs cleaner. https://github.com/andhus/scantree/actions/runs/7437164297/job/20234490230?pr=19#step:6:23