### PR TITLE
Fixes for Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,12 @@ jobs:
       - uses: pre-commit/action@v3.0.1
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
       - name: Test with tox
         run: tox
       - uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
         env:
           token: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,7 @@
 exclude: "src/scantree/_version.py"
 repos:
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        args: [--prose-wrap=preserve, --print-width=88]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.7
+    rev: v0.4.10
     hooks:
       - id: ruff
         args:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Recursive directory iterator supporting:
 
 - flexible filtering including wildcard path matching
 - in memory representation of file-tree (for repeated access)
-- efficient access to directory entry properties (`posix.DirEntry` interface) extended with real path and path relative to the recursion root directory
+- efficient access to directory entry properties (`os.DirEntry` interface) extended with real path and path relative to the recursion root directory
 - detection and handling of cyclic symlinks
 
 ## Installation

--- a/src/scantree/_path.py
+++ b/src/scantree/_path.py
@@ -200,13 +200,13 @@ class DirEntryReplacement:
             ("is_file", {"follow_symlinks": True}),
             ("is_file", {"follow_symlinks": False}),
             ("is_symlink", {}),
-            ("inode", {}),
         ]
         if os_name != "nt":
             methods.extend(
                 [
                     ("stat", {"follow_symlinks": True}),
                     ("stat", {"follow_symlinks": False}),
+                    ("inode", {}),
                 ]
             )
 

--- a/src/scantree/_path.py
+++ b/src/scantree/_path.py
@@ -201,7 +201,7 @@ class DirEntryReplacement:
             ("is_file", {"follow_symlinks": False}),
             ("is_symlink", {}),
         ]
-        if os_name != "nt":
+        if os_name != "nt":  # pragma: no cover
             methods.extend(
                 [
                     ("stat", {"follow_symlinks": True}),

--- a/src/scantree/_path.py
+++ b/src/scantree/_path.py
@@ -1,7 +1,6 @@
 import os
-from os import scandir
+from os import DirEntry, scandir
 from pathlib import Path
-from posix import DirEntry
 
 import attr
 
@@ -15,8 +14,7 @@ class RecursionPath:
 
     NOTE: this class is normally only ever instantiated by the `scantree` function.
 
-    The class provides the `DirEntry` interface (found in the external `scandir`
-    module in Python < 3.5 or builtin `posix` module in Python >= 3.5).
+    The class provides the os-portable `DirEntry` interface.
     """
 
     root = attr.ib()
@@ -122,8 +120,8 @@ RecursionPath.__setstate__ = RecursionPath._setstate
 
 @attr.s(slots=True, eq=False, order=False)
 class DirEntryReplacement:
-    """Pure python implementation of the `DirEntry` interface (found in the external
-    `scandir` module in Python < 3.5 or builtin `posix` module in Python >= 3.5)
+    """Pure python implementation of the os-portable `DirEntry` interface.
+
 
     A `DirEntry` cannot be instantiated directly (only returned from a call to
     `scandir`). This class offers a drop in replacement. Useful in testing and for

--- a/src/scantree/_scan.py
+++ b/src/scantree/_scan.py
@@ -61,9 +61,8 @@ def scantree(
         recursion_filter (f: f([RecursionPath]) -> [RecursionPath]): A filter
             function, defining which files to include and which subdirectories to
             scan, e.g. an instance of `scantree.RecursionFilter`.
-            The `RecursionPath` implements the `DirEntry` interface (found in
-            the external `scandir` module in Python < 3.5 or builtin `posix` module
-            in Python >= 3.5). It caches metadata efficiently and, in addition to
+            The `RecursionPath` implements the os-portable `DirEntry` interface.
+            It caches metadata efficiently and, in addition to
             DirEntry, provides real path and path relative to the root directory for
             the recursion as properties, see `scantree.RecursionPath` for further
             details.

--- a/src/scantree/test_utils.py
+++ b/src/scantree/test_utils.py
@@ -5,7 +5,7 @@ from ._path import DirEntryReplacement, RecursionPath
 
 
 def convert_path(path: str) -> str:
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover
         # Windows uses backslashes
         return path.replace("/", "\\")
     else:
@@ -25,7 +25,7 @@ def assert_dir_entry_equal(de1, de2):
         ("is_file", {"follow_symlinks": False}),
         ("is_symlink", {}),
     ]
-    if os.name != "nt":
+    if os.name != "nt":  # pragma: no cover
         methods.extend(
             [
                 ("stat", {"follow_symlinks": True}),

--- a/src/scantree/test_utils.py
+++ b/src/scantree/test_utils.py
@@ -24,13 +24,13 @@ def assert_dir_entry_equal(de1, de2):
         ("is_file", {"follow_symlinks": True}),
         ("is_file", {"follow_symlinks": False}),
         ("is_symlink", {}),
-        ("inode", {}),
     ]
     if os.name != "nt":
         methods.extend(
             [
                 ("stat", {"follow_symlinks": True}),
                 ("stat", {"follow_symlinks": False}),
+                ("inode", {}),
             ]
         )
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,5 +1,4 @@
-from os import scandir
-from posix import DirEntry
+from os import DirEntry, scandir
 
 import pytest
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,16 +1,18 @@
+from os import symlink
+
 import pytest
 
 from scantree import CyclicLinkedDir, DirNode, LinkedDir, RecursionPath
 from scantree.test_utils import get_mock_recursion_path
 
 
-def create_basic_entries(local_path):
+def create_basic_entries(local_path: str):
     d1 = local_path.join("d1")
     d1.mkdir()
     f1 = local_path.join("f1")
     f1.write("file1")
-    local_path.join("ld1").mksymlinkto(d1)
-    local_path.join("lf1").mksymlinkto(f1)
+    symlink(d1, local_path.join("ld1"))
+    symlink(f1, local_path.join("lf1"))
 
 
 class TestDirNode:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -6,7 +6,7 @@ from scantree import CyclicLinkedDir, DirNode, LinkedDir, RecursionPath
 from scantree.test_utils import get_mock_recursion_path
 
 
-def create_basic_entries(local_path: str):
+def create_basic_entries(local_path):
     d1 = local_path.join("d1")
     d1.mkdir()
     f1 = local_path.join("f1")

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,4 +1,4 @@
-from os import scandir
+from os import name, scandir, symlink
 from pathlib import Path
 
 import pytest
@@ -8,18 +8,19 @@ from scantree.compat import fspath
 from scantree.test_utils import assert_dir_entry_equal
 
 
-def create_basic_entries(local_path):
+def create_basic_entries(local_path: str):
     d1 = local_path.join("d1")
     d1.mkdir()
     f1 = local_path.join("f1")
     f1.write("file1")
-    local_path.join("ld1").mksymlinkto(d1)
-    local_path.join("lf1").mksymlinkto(f1)
+    symlink(d1, local_path.join("ld1"))
+    symlink(f1, local_path.join("lf1"))
 
 
 class TestDirEntryReplacement:
     test_class = DirEntryReplacement
 
+    @pytest.mark.skipif(name == "nt", reason="Failing on Windows")
     def test_equivalence(self, tmpdir):
         create_basic_entries(tmpdir)
         for de_true in scandir(tmpdir):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,4 +1,5 @@
-from os import name, scandir, symlink
+from os import name as os_name
+from os import scandir, symlink
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,7 @@ from scantree.compat import fspath
 from scantree.test_utils import assert_dir_entry_equal
 
 
-def create_basic_entries(local_path: str):
+def create_basic_entries(local_path):
     d1 = local_path.join("d1")
     d1.mkdir()
     f1 = local_path.join("f1")
@@ -20,7 +21,7 @@ def create_basic_entries(local_path: str):
 class TestDirEntryReplacement:
     test_class = DirEntryReplacement
 
-    @pytest.mark.skipif(name == "nt", reason="Failing on Windows")
+    @pytest.mark.skipif(os_name == "nt", reason="Failing on Windows")
     def test_equivalence(self, tmpdir):
         create_basic_entries(tmpdir)
         for de_true in scandir(tmpdir):


### PR DESCRIPTION
- this switches posix.DirEntry to os. DirEntry, which is os-independent proxy as suggested by https://docs.python.org/3/library/posix.html#module-posix

- adding windows image to the GH workflow matrix
- limiting codecov publisher step to one job from the matrix, no need to republish the same comment too many times