### PR TITLE
Allow scantree to work on Windows

### DIFF
--- a/src/scantree/_path.py
+++ b/src/scantree/_path.py
@@ -1,7 +1,7 @@
 import os
 from os import scandir
 from pathlib import Path
-from posix import DirEntry
+from os import DirEntry
 
 import attr
 


### PR DESCRIPTION
The `posix` Python module does not exist on Windows. Consequently, `import dirhash` fails on Windows because of this `scantree` dependency.

This change allows `import dirhash` to succeed on Windows and calculate hashes successfully